### PR TITLE
Fix: Discord 斜杠命令正确转换

### DIFF
--- a/src/nonebot_plugin_alconna/adapters/discord.py
+++ b/src/nonebot_plugin_alconna/adapters/discord.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Type, Union, Optional
 
 from nonebot.rule import Rule
+from tarina.const import Empty
 from nonebot.adapters import Event
 from nonebot.permission import Permission
 from nonebot.dependencies import Dependent
@@ -97,7 +98,7 @@ MentionID = (
 """
 
 
-def _translate_args(args: Args) -> list[AnyCommandOption]:
+def _translate_args(args: Args) -> List[AnyCommandOption]:
     result = []
     for arg in args:
         if isinstance(arg.value, UnionPattern):
@@ -240,13 +241,15 @@ def _translate_options(opt: Union[Option, Subcommand]) -> Union[SubCommandGroupO
             description=opt.help_text,
             options=_translate_args(opt.args),  # type: ignore
         )
-    res = SubCommandGroupOption(
+    if opt.args is not Empty:
+        return SubCommandOption(
+            name=opt.name, description=opt.help_text, options=_translate_args(opt.args)  # type: ignore
+        )
+    return SubCommandGroupOption(
         name=opt.name,
         description=opt.help_text,
         options=[_translate_options(sub) for sub in opt.options],  # type: ignore
     )
-    res.options.extend(_translate_args(opt.args))  # type: ignore
-    return res
 
 
 def translate(
@@ -307,15 +310,19 @@ class DiscordExtension(Extension, ApplicationCommandMatcher):
         super().__init__()
 
     def post_init(self, alc: Alconna) -> None:
-        options = [_translate_options(opt) for opt in alc.options]
-        options.extend(_translate_args(alc.args))
+        if not (options := _translate_args(alc.args)):
+            options = [
+                _translate_options(opt)
+                for opt in alc.options
+                if opt.name not in alc.namespace_config.builtin_option_name
+            ]
         config = ApplicationCommandConfig(
             type=ApplicationCommandType.CHAT_INPUT,
             name=alc.command,
             name_localizations=self.name_localizations,
             description=self.description or alc.meta.description,
             description_localizations=self.description_localizations,
-            options=options,
+            options=options,  # type: ignore
             default_member_permissions=self.default_member_permissions,
             dm_permission=self.dm_permission,
             default_permission=self.default_permission,
@@ -346,7 +353,8 @@ class DiscordExtension(Extension, ApplicationCommandMatcher):
             ):
                 yield f"{opt.name}"
                 if opt.options:
-                    yield from (_handle_option(o) for o in opt.options)
+                    for o in opt.options:
+                        yield from _handle_option(o)
             else:
                 yield f"{opt.value}"
 

--- a/src/nonebot_plugin_alconna/adapters/discord.py
+++ b/src/nonebot_plugin_alconna/adapters/discord.py
@@ -319,16 +319,13 @@ class DiscordExtension(Extension, ApplicationCommandMatcher):
                 f'prefix of Alconna::{alc.name} with DiscordExtension is not ["/"], '
                 "the slash command will not respond properly"
             )
-        if not alc.args.empty and alc.options:
+        allow_opt = [opt for opt in alc.options if opt.name not in alc.namespace_config.builtin_option_name]
+        if not alc.args.empty and allow_opt:
             logger.warning(
                 f"cannot have both Args and Option/Subcommand in Alconna::{alc.name} with DiscordExtension"
             )
         if not (options := _translate_args(alc.args)):
-            options = [
-                _translate_options(opt)
-                for opt in alc.options
-                if opt.name not in alc.namespace_config.builtin_option_name
-            ]
+            options = [_translate_options(opt) for opt in allow_opt]
         config = ApplicationCommandConfig(
             type=ApplicationCommandType.CHAT_INPUT,
             name=alc.command,

--- a/src/nonebot_plugin_alconna/adapters/discord.py
+++ b/src/nonebot_plugin_alconna/adapters/discord.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Type, Union, Optional
 
 from nonebot.rule import Rule
-from tarina.const import Empty
 from nonebot.adapters import Event
 from nonebot.permission import Permission
 from nonebot.dependencies import Dependent
@@ -241,7 +240,7 @@ def _translate_options(opt: Union[Option, Subcommand]) -> Union[SubCommandGroupO
             description=opt.help_text,
             options=_translate_args(opt.args),  # type: ignore
         )
-    if opt.args is not Empty:
+    if not opt.args.empty:
         return SubCommandOption(
             name=opt.name, description=opt.help_text, options=_translate_args(opt.args)  # type: ignore
         )

--- a/src/nonebot_plugin_alconna/adapters/discord.py
+++ b/src/nonebot_plugin_alconna/adapters/discord.py
@@ -319,7 +319,11 @@ class DiscordExtension(Extension, ApplicationCommandMatcher):
                 f'prefix of Alconna::{alc.name} with DiscordExtension is not ["/"], '
                 "the slash command will not respond properly"
             )
-        allow_opt = [opt for opt in alc.options if opt.name not in alc.namespace_config.builtin_option_name]
+        allow_opt = [
+            opt
+            for opt in alc.options
+            if opt.name not in set().union(*alc.namespace_config.builtin_option_name.values())  # type: ignore
+        ]
         if not alc.args.empty and allow_opt:
             logger.warning(
                 f"cannot have both Args and Option/Subcommand in Alconna::{alc.name} with DiscordExtension"


### PR DESCRIPTION
Discord 的斜杠命令不支持同时拥有参数和子命令(组)，因此在转换 Alconna 至 Discord 的斜杠命令时进行部分判断处理：
- 当 Alconna 同时有参数和子命令时，优先使用参数，丢弃子命令
- 忽略 Alconna 自带的 `shortcut` 和 `comp` 子命令

另外：
- 修复了 ExtensionExecutor 的 select 排序问题
- 修复了 DiscordExtension 的 `message_provider` 转换问题