### PR TITLE
修复UniMessage.dump(media_save_dir=False,json=True)时，序列化失败的问题

### DIFF
--- a/src/nonebot_plugin_alconna/uniseg/segment.py
+++ b/src/nonebot_plugin_alconna/uniseg/segment.py
@@ -151,6 +151,9 @@ class Segment:
                 data.pop("raw", None)
                 data.pop("mimetype", None)
                 data["path"] = str(path.resolve().as_posix())
+            elif media_save_dir is False:
+                data.pop("raw", None)
+                data.pop("mimetype", None)
         if self._children:
             data["children"] = [child.dump(media_save_dir=media_save_dir) for child in self._children]
         return data


### PR DESCRIPTION
如果`not self.url`，`not self.path`，`self.raw`存在数据，`media_save_dir=False`时，
所有分支都会被跳过，`self.raw`会被保留，最后在`json.dumps`时报错：
```
TypeError: Object of type bytes is not JSON serializable
when serializing dict item 'raw'
when serializing list item 0
```